### PR TITLE
Handle file removal before exiting editor

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -610,18 +610,14 @@ impl Screen {
         // read new data
         let mut data = vec![];
 
-        #[allow(unused_must_use)]
         {
             // File closed as it slides out of scope.
-            File::open(&path).and_then(|mut f| f.read_to_end(&mut data));
+            let _ = File::open(&path).and_then(|mut f| f.read_to_end(&mut data));
         }
 
         let new_text = String::from_utf8(data).unwrap();
 
-        #[allow(unused_must_use)]
-        {
-            remove_file(&path);
-        }
+        let _ = remove_file(&path);
 
         // set node's saved text
         self.with_node_mut(node_id, |n| n.free_text = Some(new_text.clone()))

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -609,14 +609,19 @@ impl Screen {
 
         // read new data
         let mut data = vec![];
+
+        #[allow(unused_must_use)]
         {
-            let mut f = File::open(&path).unwrap();
-            f.read_to_end(&mut data).unwrap();
-            // f closed as it slides out of scope
+            // File closed as it slides out of scope.
+            File::open(&path).and_then(|mut f| f.read_to_end(&mut data));
         }
+
         let new_text = String::from_utf8(data).unwrap();
 
-        remove_file(&path).unwrap();
+        #[allow(unused_must_use)]
+        {
+            remove_file(&path);
+        }
 
         // set node's saved text
         self.with_node_mut(node_id, |n| n.free_text = Some(new_text.clone()))


### PR DESCRIPTION
Without this, if the text editor doesn't end up writing the file, the unwrap
will fail and crash the application needlessly. I ran into this when I deleted
the empty file.