### PR TITLE
Visually mark notes

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1824,6 +1824,8 @@ impl Screen {
                 write!(&mut buf, "⊞").unwrap();
             } else if node.hide_stricken {
                 write!(&mut buf, "⚔").unwrap();
+            } else if node.free_text.is_some() {
+                write!(&mut buf, "✏").unwrap();
             } else {
                 write!(&mut buf, " ").unwrap();
             }


### PR DESCRIPTION
Currently we have to remember which nodes have notes. This saves the effort,
and has the lowest priority to avoid overwriting TODO items and nested trees.