### PR TITLE
Implement parent selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ de-select node | Esc | save | C-x
 exit | Esc with nothing selected | exit | C-c
 jump to weighted next task | C-v | cut / paste node | C-y
 move selected up in child list | C-g | move selected down in child list | C-d
-search for node at or below current view | C-u
+search for node at or below current view | C-u | Select parent | A-p
 
 can be customized by setting the `KEYFILE` env var to the path of a [key configuration file](default.keys)
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -42,6 +42,7 @@ to specify a different storage file:
     result.
 4.  `C-f`: search for visible nodes by entering its first letter
 5.  `<letter of match>` letters will show up next to options
+6.  `<A-p>`: Select parent of current node.
 
 #### scopes
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub enum Action {
     Search,
     UndoDelete,
     Help,
+    SelectParent,
 }
 
 fn to_action(input: String) -> Option<Action> {
@@ -81,6 +82,7 @@ fn to_action(input: String) -> Option<Action> {
         "search" => Some(Action::Search),
         "undo_delete" => Some(Action::UndoDelete),
         "help" => Some(Action::Help),
+        "select_parent" => Some(Action::SelectParent),
         _ => None,
     }
 }
@@ -158,6 +160,7 @@ impl Default for Config {
                 (Ctrl('u'), Action::Search),
                 (Ctrl('z'), Action::UndoDelete),
                 (Ctrl('?'), Action::Help),
+                (Alt('p'), Action::SelectParent),
             ]
             .into_iter()
             .collect(),

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -220,6 +220,7 @@ impl Screen {
                 Action::LowerSelected => self.lower_selected(),
                 Action::Search => self.search_forward(),
                 Action::UndoDelete => self.undo_delete(),
+                Action::SelectParent => self.select_parent(),
             },
             None => warn!("received unknown input"),
         }
@@ -1239,6 +1240,19 @@ impl Screen {
         self.drawing_root = root;
         self.view_y = view_y;
         self.select_node(selected);
+    }
+
+    fn select_parent(&mut self) {
+        if let Some(selected_id) = self.selected {
+            // If no parent, this should be a no-op.
+            if let Some(parent_id) = self.parent(selected_id) {
+                // If we're at a toplevel task (i.e., 0 is its parent ID), we don't want to
+                // deselect it.
+                if parent_id != 0 {
+                    self.select_node(parent_id);
+                }
+            }
+        }
     }
 
     fn drill_down(&mut self) {


### PR DESCRIPTION
Handy for navigating trees. If the task is at the toplevel (0 is its parent
id), then does not change selection.

@spacekookie