### PR TITLE
Write to default path if CLI `PATH` arg is `None`

### DIFF
--- a/src/bin/void/main.rs
+++ b/src/bin/void/main.rs
@@ -15,10 +15,12 @@ fn main() {
     let path: OsString = matches
         .value_of("PATH")
         .map(OsString::from)
-        .or_else(|| dirs::home_dir().and_then(|mut h| {
-            h.push(".void.db");
-            Some(h.into_os_string())
-        }))
+        .or_else(|| {
+            dirs::home_dir().and_then(|mut h| {
+                h.push(".void.db");
+                Some(h.into_os_string())
+            })
+        })
         .unwrap();
 
     // load from file if present

--- a/src/bin/void/main.rs
+++ b/src/bin/void/main.rs
@@ -14,8 +14,8 @@ fn main() {
 
     let path: OsString = matches
         .value_of("PATH")
-        .map(|p| OsString::from(p))
-        .or(dirs::home_dir().and_then(|mut h| {
+        .map(OsString::from)
+        .or_else(|| dirs::home_dir().and_then(|mut h| {
             h.push(".void.db");
             Some(h.into_os_string())
         }))
@@ -27,7 +27,7 @@ fn main() {
         .write(true)
         .read(true)
         .create(true)
-        .open(path)
+        .open(&path)
         .unwrap();
 
     // exclusively lock the file
@@ -39,7 +39,11 @@ fn main() {
 
     // Initialise the main working screen
     let mut screen = saved_screen.unwrap_or_else(Screen::default);
-    screen.work_path = matches.value_of("PATH").map(|s| s.into());
+
+    screen.work_path = matches
+        .value_of("PATH")
+        .map(|s| s.into())
+        .or_else(|| Some(path.into_string().unwrap()));
 
     let config = Config::maybe_parsed_from_env().unwrap();
     screen.config = config;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -19,7 +19,7 @@ impl log::Log for ScreenLogger {
             "{} {} {}:{}] {}\n",
             time::get_time().sec,
             record.level(),
-            record.location().file().split("/").last().unwrap(),
+            record.location().file().split('/').last().unwrap(),
             record.location().line(),
             record.args()
         );


### PR DESCRIPTION
Otherwise we end up just ignoring the default path.

This has bitten me where if I don't use this, none of my changes to my default
document are registered.