### PR TITLE
Implement selecting next/prev siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ de-select node | Esc | save | C-x
 exit | Esc with nothing selected | exit | C-c
 jump to weighted next task | C-v | cut / paste node | C-y
 move selected up in child list | C-g | move selected down in child list | C-d
-search for node at or below current view | C-u | Select parent | A-p
+search for node at or below current view | C-u | Select parent | A-S-p (alt shift)
+Select next sibling | A-n | select previous sibling | A-p
 
 can be customized by setting the `KEYFILE` env var to the path of a [key configuration file](default.keys)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,8 @@ pub enum Action {
     UndoDelete,
     Help,
     SelectParent,
+    SelectNextSibling,
+    SelectPrevSibling,
 }
 
 fn to_action(input: String) -> Option<Action> {
@@ -83,6 +85,8 @@ fn to_action(input: String) -> Option<Action> {
         "undo_delete" => Some(Action::UndoDelete),
         "help" => Some(Action::Help),
         "select_parent" => Some(Action::SelectParent),
+        "select_next_sibling" => Some(Action::SelectNextSibling),
+        "select_prev_sibling" => Some(Action::SelectPrevSibling),
         _ => None,
     }
 }
@@ -160,7 +164,9 @@ impl Default for Config {
                 (Ctrl('u'), Action::Search),
                 (Ctrl('z'), Action::UndoDelete),
                 (Ctrl('?'), Action::Help),
-                (Alt('p'), Action::SelectParent),
+                (Alt('P'), Action::SelectParent),
+                (Alt('n'), Action::SelectNextSibling),
+                (Alt('p'), Action::SelectPrevSibling),
             ]
             .into_iter()
             .collect(),


### PR DESCRIPTION
In the general vein of navigation enhancements.

This also changes the mapping to select parent to Alt shift p instead of
alt-p, but that's not much of a change since 'select parent' was only
implemented yesterday and is not in any official release.