### PR TITLE
Don't exit void when pressing Unselect key

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -167,29 +167,31 @@ impl Screen {
                 Action::LeftClick(x, y) => {
                     let internal_coords = self.screen_to_internal_xy((x, y));
                     self.click_screen(internal_coords)
-                },
+                }
                 Action::RightClick(..) => {
                     self.pop_focus();
-                },
+                }
                 Action::Release(x, y) => {
                     let internal_coords = self.screen_to_internal_xy((x, y));
                     self.release(internal_coords)
-                },
+                }
                 // Write character to selection
                 Action::Char(c) if self.selected.is_some() => {
                     self.append(c);
-                },
+                }
                 Action::Char('/') => {
                     self.search_forward();
-                },
+                }
                 Action::Char('?') => {
                     self.search_backward();
-                },
+                }
                 Action::Char(c) => {
                     self.prefix_jump_to(c.to_string());
-                },
+                }
                 Action::Help => self.help(),
-                Action::UnselectRet => return self.unselect().is_some(),
+                Action::UnselectRet => {
+                    self.unselect();
+                }
                 Action::ScrollUp => self.scroll_up(),
                 Action::ScrollDown => self.scroll_down(),
                 Action::DeleteSelected => self.delete_selected(true),


### PR DESCRIPTION
Often it happens that when I'm trying to ensure that nothing is selected (by pressing the Unselect key), void exits because indeed nothing was selected. This gives me the burden of checking for a selection before I can start using commands. This PR makes the Unselect key behave consistently.