### PR TITLE
Overhaul arrow pathfinding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub type Coords = (u16, u16);
 pub type NodeID = u64;
 pub type ScreenDesc = (HashMap<Coords, NodeID>, HashMap<NodeID, Coords>);
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Dir {
     L,
     R,

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -2077,7 +2077,6 @@ impl Screen {
     }
 
     fn path_from_node_to_point(&self, start: NodeID, to: Coords) -> (Vec<Coords>, (Dir, Dir)) {
-        // TODO this is mostly copypasta from path_between_nodes, DRY
         trace!("getting path between node {} and point {:?}", start, to);
         let startbounds = self.bounds_for_lookup(start);
         if startbounds.is_none() {
@@ -2085,17 +2084,11 @@ impl Screen {
             return (vec![], (Dir::R, Dir::R));
         }
         let (s1, s2) = startbounds.unwrap();
-        let init = (self.path(s2, to), (Dir::R, Dir::R));
-        let paths = vec![(self.path(s1, to), (Dir::L, Dir::R))];
-        paths
-            .into_iter()
-            .fold(init, |(spath, sdirs), (path, dirs)| {
-                if path.len() < spath.len() {
-                    (path, dirs)
-                } else {
-                    (spath, sdirs)
-                }
-            })
+
+        self.path_with_directions(
+            &[(s1, Dir::L), (s2, Dir::R)],
+            &[(to, Dir::R)],
+        )
     }
 
     fn path_between_nodes(&self, start: NodeID, to: NodeID) -> (Vec<Coords>, (Dir, Dir)) {
@@ -2109,28 +2102,44 @@ impl Screen {
         let (s1, s2) = startbounds.unwrap();
         let (t1, t2) = tobounds.unwrap();
 
-        let init = (self.path(s2, t2), (Dir::R, Dir::R));
-        let paths = vec![
-            (self.path(s1, t2), (Dir::L, Dir::R)),
-            (self.path(s2, t1), (Dir::R, Dir::L)),
-            (self.path(s1, t1), (Dir::L, Dir::L)),
-        ];
-        paths
-            .into_iter()
-            .fold(init, |(spath, sdirs), (path, dirs)| {
-                if path.len() < spath.len() {
-                    (path, dirs)
-                } else {
-                    (spath, sdirs)
-                }
-            })
+        self.path_with_directions(
+            &[(s1, Dir::L), (s2, Dir::R)],
+            &[(t1, Dir::L), (t2, Dir::R)],
+        )
     }
 
-    fn path(&self, start: Coords, dest: Coords) -> Vec<Coords> {
+    fn path_with_directions(
+        &self,
+        starts: &[(Coords, Dir)],
+        dests: &[(Coords, Dir)]
+    ) -> (Vec<Coords>, (Dir, Dir)) {
+        let dests_no_dir: Vec<Coords> = dests.iter()
+            .map(|(coords, _)| *coords)
+            .collect();
+        let path = self.path(starts, &dests_no_dir);
+        let last_node = if let Some(n) = path.last() { n } else {
+            return (path, (Dir::L, Dir::R));
+        };
+        let first_node = path.first().unwrap();
+        let last_dir = dests.iter()
+            .filter(|(dest, _)| dest == last_node)
+            .map(|(_, dir)| dir)
+            .next()
+            .unwrap();
+        let first_dir = starts.iter()
+            .filter(|(start, _)| start == first_node)
+            .map(|(_, dir)| dir)
+            .next()
+            .unwrap();
+
+        (path, (*first_dir, *last_dir))
+    }
+
+    fn path(&self, starts: &[(Coords, Dir)], dests: &[Coords]) -> Vec<Coords> {
         trace!(
             "path({:?}, {:?} (screen size: {} x {})",
-            start,
-            dest,
+            starts,
+            dests,
             self.dims.0,
             self.dims.1
         );
@@ -2143,19 +2152,36 @@ impl Screen {
                 (c.0, max(c.1, 2) - 1),
             ]
         }
+        let heuristic = |from: Coords|
+            dests.iter()
+                .map(|dest| cost(from, *dest))
+                .min()
+                .unwrap_or(std::u16::MAX);
         // maps from location to previous location
         let mut visited: HashMap<Coords, (Coords, u16)> = HashMap::new();
-        let mut pq = BinaryHeap::new();
 
-        let mut cursor = start;
-        let mut cursor_cost = 0; // The cost to get to the coords of the cursor so far
-        let mut cursor_last_direction = 0;
+        // priority queue of nodes to explore, initially populated w/ starting locs
+        // tuple is (priority, coords, last_direction, cost)
+        let mut pq: BinaryHeap<_> = starts.into_iter()
+            .map(|(point, dir)| (
+                std::u16::MAX - heuristic(*point),
+                *point,
+                match dir {
+                    Dir::L => -1,
+                    Dir::R => 1,
+                },
+                0
+            ))
+            .collect();
+
+        let (_, mut cursor, mut cursor_last_direction, mut cursor_cost) =
+            pq.pop().expect("path() called without any starting point");
         trace!("starting draw");
-        while cursor != dest {
+        while !dests.contains(&cursor) {
             for neighbor in perms(cursor) {
                 // direction is -2, -1, 1, or 2
-                let direction = (cursor.0 as i32) - (neighbor.0 as i32)
-                    + 2 * ((cursor.1 as i32) - (neighbor.1 as i32));
+                let direction = (neighbor.0 as i32) - (cursor.0 as i32)
+                         + 2 * ((neighbor.1 as i32) - (cursor.1 as i32));
 
                 let move_cost = if cursor_last_direction == direction {
                     1 // We're moving in the same direction as before: free
@@ -2164,8 +2190,8 @@ impl Screen {
                 };
 
                 let turn_into_dest_cost = if
-                    neighbor == dest &&
-                    (direction == -2 || direction == 2)
+                    (direction == -2 || direction == 2) &&
+                    heuristic(neighbor) == 0
                 {
                     // When we arrive at dest, it's good to be traveling in the direction
                     // that the carrot will be pointing.  e.g.
@@ -2184,14 +2210,13 @@ impl Screen {
                 if (neighbor.0 < self.dims.0
                     && neighbor.1 < self.dims.1 + self.view_y
                     && !self.occupied(neighbor)
-                    || neighbor == dest)
+                    || dests.contains(&neighbor))
                     && visited.get(&neighbor) // Only if we found...
                         .map(|(_, old_cost)| *old_cost > total_cost) // a cheaper route...
                         .unwrap_or(true) // or the first route
                 {
-                    let heuristic = cost(neighbor, dest);
                     let priority = std::u16::MAX
-                        - heuristic
+                        - heuristic(neighbor)
                         - total_cost;
 
                     pq.push((priority, neighbor, direction, total_cost));
@@ -2211,9 +2236,9 @@ impl Screen {
         }
         trace!("done draw, starting backtrack");
 
-        let mut back_cursor = dest;
-        let mut path = vec![dest];
-        while back_cursor != start {
+        let mut back_cursor = cursor;
+        let mut path = vec![cursor];
+        while !starts.iter().any(|(start, _)| *start == back_cursor) {
             let (prev, _) = visited[&back_cursor];
             path.push(prev);
             back_cursor = prev;

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -2157,14 +2157,29 @@ impl Screen {
                 let direction = (cursor.0 as i32) - (neighbor.0 as i32)
                     + 2 * ((cursor.1 as i32) - (neighbor.1 as i32));
 
-                let this_move_cost = if cursor_last_direction == direction {
+                let move_cost = if cursor_last_direction == direction {
                     1 // We're moving in the same direction as before: free
                 } else {
                     2 // We changed direction, which is discouraged to arrows simple
                 };
 
+                let turn_into_dest_cost = if
+                    neighbor == dest &&
+                    (direction == -2 || direction == 2)
+                {
+                    // When we arrive at dest, it's good to be traveling in the direction
+                    // that the carrot will be pointing.  e.g.
+                    //
+                    // Bad: ──┐       Good:─┐
+                    //        │             │
+                    //        >dest         └─>dest
+                    5
+                } else {
+                    0
+                };
+
                 // Total cost to get to this point
-                let total_cost = this_move_cost + cursor_cost;
+                let total_cost = move_cost + turn_into_dest_cost + cursor_cost;
 
                 if (neighbor.0 < self.dims.0
                     && neighbor.1 < self.dims.1 + self.view_y


### PR DESCRIPTION
Currently, arrow pathfinding works using the following algorithm:
- for each possible starting point (typically = 2)
  - for each possible ending point (1 for a point, 2 for a node)
    - run a greedy search from the start to the end
-  pick the fastest path

This algorithm often creates arrows that are way squigglier and hard to follow than they really need to be.  Additionally, it often does four times more work than it needs to, because it runs once for every combination of start and end points.

This PR replaces the greedy search algorithm with a slightly more expensive A* algorithm, while also using an algorithm that allows automatically picking the best path from one of a number of start points to one of a number of end points, eliminating the need to run the algorithm more than once.

By using an A* algorithm, we also gain more control over the pathfinding, by the use of weights.  This PR takes advantage of this fact to improve arrow generation in the following ways:
- Making more turns than necessary is discouraged, decreasing line squigle factor (cost +1 / turn)
- Pointing in the direction of the end arrow is encouraged (cost +5 if ending in the wrong direction, see 69241df)

This also opens the door for future work in order to discourage arrows from overlapping for long distances, but that's left to another PR.

## Before
![image](https://user-images.githubusercontent.com/38897201/176729233-1b4569df-121a-4942-9f6e-15434d794a41.png)

## After
![image](https://user-images.githubusercontent.com/38897201/176729506-19b75c6c-b754-4642-acb9-c67d68cf5727.png)