### PR TITLE
Enable strong LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ fs2 = "0.4.3"
 
 [dev-dependencies]
 quickcheck = "0.9.2"
+
+[profile.release]
+lto=true
+codegen-units=1


### PR DESCRIPTION
This turns on the LTO flag for release builds, in addition to reducing the number of codegen units, thus improving the LTO.

This will lead to significant performance improvements at the cost of release build times.  However, since `void` has a relatively small dependency tree, and itself is not so complicated as to make release builds excruciatingly long, I think that this is a worthwhile tradeoff, although it is entirely at your discression